### PR TITLE
Contact trigger updated

### DIFF
--- a/src/classes/ContactTriggerHandler.cls
+++ b/src/classes/ContactTriggerHandler.cls
@@ -24,6 +24,13 @@ public class ContactTriggerHandler {
         for(Contact con : contactListNew != null ? contactListNew : contactListOld){
             setOfAccIds.add(con.AccountId);
         }
+        //Adding those Acc Ids which were in a contact record before an update
+        //So that we can update the fields of the old Parent Account of a Contact after an update
+        if(contactListOld !=null){
+            for(Contact con : contactListOld){
+                setOfAccIds.add(con.AccountId);
+            }
+        }
         List<AggregateResult> groupedResult =[SELECT AccountId, COUNT(Id) totConts FROM Contact WHERE AccountId IN: setOfAccIds
                                                 GROUP BY AccountId];
         Set<Id> IdOfContsFromResult = new  Set<Id>();      //This Id set excludes those ACC Ids that have no related contact                                   
@@ -48,6 +55,8 @@ public class ContactTriggerHandler {
             setOfAccToUpdate.add(ac);
         }
         listOfAccToUpdate.addAll(setOfAccToUpdate);
-        update listOfAccToUpdate;
+        if(listOfAccToUpdate.size()>0){
+            update listOfAccToUpdate;
+        }
     }
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,22 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
-        <members>AccountTriggerHandler</members>
         <members>ContactTriggerHandler</members>
         <name>ApexClass</name>
     </types>
     <types>
         <members>ContactTrigger</members>
-        <members>Trigger_Account</members>
         <name>ApexTrigger</name>
-    </types>
-    <types>
-        <members>Account.Num_of_Contacts__c</members>
-        <name>CustomField</name>
-    </types>
-    <types>
-        <members>Account.Check_Account_Type_Changed</members>
-        <name>ValidationRule</name>
     </types>
     <version>53.0</version>
 </Package>

--- a/src/triggers/ContactTrigger.trigger
+++ b/src/triggers/ContactTrigger.trigger
@@ -9,11 +9,11 @@
  * 	Revision Logs	: 	V_1.0 - Created By - Soumi Chakraborty - 26/07/2022
  * 
  * */
-trigger ContactTrigger on Contact (after insert,after delete, after undelete) {
+trigger ContactTrigger on Contact (after insert,after update,after delete, after undelete) {
 	if(Trigger.isAfter){
         //Increments total number of contacts field in Account obj when a related contact is inserted or undeleted.
         //And decrements total number of contacts field in Account obj when a related contact is deleted.
-        if(Trigger.isInsert || Trigger.isDelete || Trigger.isUndelete){
+        if(Trigger.isInsert ||Trigger.isUpdate || Trigger.isDelete || Trigger.isUndelete){
             ContactTriggerHandler.populateNumOfContactsOnAccount(Trigger.New,Trigger.old);
             //Trigger.old will be null for after insert and after undelete
             //Trigger.old will not be null for after delete


### PR DESCRIPTION
1)Added After Update event in the contact trigger because sometimes a contact that is not linked to any parent account can be update and linked to a parent account.
2)The contact maybe updated and linked to a new Account from an old Account so update trigger will update the tot number of fields in the new linked account as well as old lined account.